### PR TITLE
Fix global template validation

### DIFF
--- a/src/app/features/templates/template-wizard.component.ts
+++ b/src/app/features/templates/template-wizard.component.ts
@@ -466,6 +466,10 @@ export class TemplateWizardComponent {
 
   isMetaValid(): boolean {
     const m = this.meta();
+    if (m.isGlobal) {
+      // For global templates only the name and contract type are required
+      return !!(m.name && m.contractType);
+    }
     return !!(m.name && m.contractType && m.country && m.state && m.city);
   }
-} 
+}


### PR DESCRIPTION
## Summary
- allow global templates to skip location fields

## Testing
- `npx ng test --browsers=ChromeHeadless --watch=false --no-progress` *(fails: connect EHOSTUNREACH)*