### PR TITLE
Add unit & Cypress component tests for templates

### DIFF
--- a/cypress/support/component/add-standard-clause.component.cy.ts
+++ b/cypress/support/component/add-standard-clause.component.cy.ts
@@ -1,0 +1,29 @@
+import { mount } from 'cypress/angular';
+import { AddStandardClauseComponent } from '../../../src/app/features/templates/add-standard-clause.component';
+
+describe('AddStandardClauseComponent', () => {
+  it('emits save with form values', () => {
+    const save = cy.stub().as('save');
+    mount(AddStandardClauseComponent, {
+      componentProperties: {
+        save: { emit: save } as any
+      }
+    });
+    cy.get('input[formcontrolname="name"]').type('Clause');
+    cy.get('select[formcontrolname="type"]').select('GENERAL');
+    cy.get('input[formcontrolname="jurisdiction"]').type('US');
+    cy.get('input[formcontrolname="allowedDeviations"]').clear().type('1');
+    cy.get('textarea[formcontrolname="text"]').type('Body');
+    cy.get('form').submit();
+    cy.get('@save').should('have.been.called');
+  });
+
+  it('emits cancel when cancel clicked', () => {
+    const cancel = cy.stub().as('cancel');
+    mount(AddStandardClauseComponent, {
+      componentProperties: { cancel: { emit: cancel } as any }
+    });
+    cy.contains('button', 'Cancel').click();
+    cy.get('@cancel').should('have.been.called');
+  });
+});

--- a/cypress/support/component/clause-card-editor.component.cy.ts
+++ b/cypress/support/component/clause-card-editor.component.cy.ts
@@ -1,0 +1,23 @@
+import { mount } from 'cypress/angular';
+import { ClauseCardEditorComponent } from '../../../src/app/features/templates/clause-card-editor.component';
+import { VersionedClause } from '../../../src/app/features/templates/template-version.model';
+
+describe('ClauseCardEditorComponent', () => {
+  const clause: VersionedClause = {
+    clauseId: '1',
+    clauseType: 'type',
+    title: 'Title',
+    body: 'Body',
+    ruleJson: { enforcement: 'MUST_HAVE', severity: 'MEDIUM', allowedDeviation: 0, forbiddenPatterns: [] },
+    orderIdx: 0
+  };
+
+  it('emits save when Save clicked', () => {
+    const save = cy.stub().as('save');
+    mount(ClauseCardEditorComponent, {
+      componentProperties: { clause, save: { emit: save } as any }
+    });
+    cy.contains('button', 'Save').click();
+    cy.get('@save').should('have.been.calledWith', clause);
+  });
+});

--- a/cypress/support/component/diff-version-dialog.component.cy.ts
+++ b/cypress/support/component/diff-version-dialog.component.cy.ts
@@ -1,0 +1,13 @@
+import { mount } from 'cypress/angular';
+import { DiffVersionDialogComponent } from '../../../src/app/features/templates/diff-version-dialog.component';
+
+describe('DiffVersionDialogComponent', () => {
+  it('emits close when clicking close button', () => {
+    const close = cy.stub().as('close');
+    mount(DiffVersionDialogComponent, {
+      componentProperties: { close: { emit: close } as any }
+    });
+    cy.get('button[aria-label="Close diff dialog"]').click();
+    cy.get('@close').should('have.been.called');
+  });
+});

--- a/cypress/support/component/rule-dialog.component.cy.ts
+++ b/cypress/support/component/rule-dialog.component.cy.ts
@@ -1,0 +1,30 @@
+import { mount } from 'cypress/angular';
+import { RuleDialogComponent } from '../../../src/app/features/templates/rule-dialog.component';
+import { ClauseRule } from '../../../src/app/features/templates/template-version.model';
+
+describe('RuleDialogComponent', () => {
+  const rule: ClauseRule = {
+    enforcement: 'MUST_HAVE',
+    severity: 'MEDIUM',
+    allowedDeviation: 0,
+    forbiddenPatterns: []
+  };
+
+  it('emits save on submit', () => {
+    const save = cy.stub().as('save');
+    mount(RuleDialogComponent, {
+      componentProperties: { rule: { ...rule }, save: { emit: save } as any }
+    });
+    cy.get('form').submit();
+    cy.get('@save').should('have.been.calledWith', rule);
+  });
+
+  it('emits cancel on cancel click', () => {
+    const cancel = cy.stub().as('cancel');
+    mount(RuleDialogComponent, {
+      componentProperties: { rule: { ...rule }, cancel: { emit: cancel } as any }
+    });
+    cy.contains('button', 'Cancel').click();
+    cy.get('@cancel').should('have.been.called');
+  });
+});

--- a/cypress/support/component/standard-clause-card.component.cy.ts
+++ b/cypress/support/component/standard-clause-card.component.cy.ts
@@ -1,0 +1,20 @@
+import { mount } from 'cypress/angular';
+import { StandardClauseCardComponent, StandardClauseCardData } from '../../../src/app/features/templates/standard-clause-card.component';
+
+describe('StandardClauseCardComponent', () => {
+  const clause: StandardClauseCardData = {
+    id: '1',
+    name: 'Test',
+    type: 'TYPE',
+    text: 'Body',
+    jurisdiction: 'US',
+    allowedDeviations: 0,
+    version: '1.0'
+  };
+
+  it('toggles expansion when clicked', () => {
+    mount(StandardClauseCardComponent, { componentProperties: { clause } });
+    cy.get('button').click();
+    cy.get('svg.rotate-180').should('exist');
+  });
+});

--- a/cypress/support/component/standard-clause-form-dialog.component.cy.ts
+++ b/cypress/support/component/standard-clause-form-dialog.component.cy.ts
@@ -1,0 +1,13 @@
+import { mount } from 'cypress/angular';
+import { StandardClauseFormDialogComponent } from '../../../src/app/features/templates/standard-clause-form-dialog.component';
+
+describe('StandardClauseFormDialogComponent', () => {
+  it('emits cancel when Cancel clicked', () => {
+    const cancel = cy.stub().as('cancel');
+    mount(StandardClauseFormDialogComponent, {
+      componentProperties: { cancel: { emit: cancel } as any }
+    });
+    cy.contains('button', 'Cancel').click();
+    cy.get('@cancel').should('have.been.called');
+  });
+});

--- a/cypress/support/component/standard-clause-selector.component.cy.ts
+++ b/cypress/support/component/standard-clause-selector.component.cy.ts
@@ -1,0 +1,24 @@
+import { mount } from 'cypress/angular';
+import { of } from 'rxjs';
+import { StandardClauseSelectorComponent } from '../../../src/app/features/templates/standard-clause-selector.component';
+import { STANDARD_CLAUSE_SERVICE_TOKEN } from '../../../src/app/features/standard-clauses/standard-clauses.module';
+import { StandardClause } from '../../../src/app/features/standard-clauses/models/standard-clause.model';
+
+const clauses: StandardClause[] = [
+  { id: 1, name: 'Clause', type: 'TYPE', text: 'Text', jurisdiction: 'US', allowedDeviations: 0, version: '1.0', contractType: 'NDA', createdAt: new Date(), updatedAt: new Date(), severity: 'LOW' }
+];
+
+const service = { getAll: () => of(clauses) };
+
+describe('StandardClauseSelectorComponent', () => {
+  it('lists clauses and emits select', () => {
+    const select = cy.stub().as('select');
+    mount(StandardClauseSelectorComponent, {
+      componentProperties: { select: { emit: select } as any },
+      providers: [{ provide: STANDARD_CLAUSE_SERVICE_TOKEN, useValue: service }]
+    });
+    cy.contains('Clause').should('exist');
+    cy.contains('button', 'Select').click();
+    cy.get('@select').should('have.been.called');
+  });
+});

--- a/cypress/support/component/template-admin-page.component.cy.ts
+++ b/cypress/support/component/template-admin-page.component.cy.ts
@@ -1,0 +1,14 @@
+import { mount } from 'cypress/angular';
+import { TemplateAdminPageComponent } from '../../../src/app/features/templates/template-admin-page.component';
+import { Router } from '@angular/router';
+
+describe('TemplateAdminPageComponent', () => {
+  it('navigates on new template click', () => {
+    const navigate = cy.stub().as('navigate');
+    mount(TemplateAdminPageComponent, {
+      providers: [{ provide: Router, useValue: { navigate } }]
+    });
+    cy.contains('button', 'New Template').click();
+    cy.get('@navigate').should('have.been.calledWith', ['/templates/new']);
+  });
+});

--- a/cypress/support/component/template-version-drawer.component.cy.ts
+++ b/cypress/support/component/template-version-drawer.component.cy.ts
@@ -1,0 +1,31 @@
+import { mount } from 'cypress/angular';
+import { TemplateVersionDrawerComponent } from '../../../src/app/features/templates/template-version-drawer.component';
+import { TemplateVersion } from '../../../src/app/features/templates/template-version.model';
+
+describe('TemplateVersionDrawerComponent', () => {
+  const versions: TemplateVersion[] = [
+    { versionId: '1', templateId: 't1', versionNo: '1', createdAt: new Date(), createdBy: 'A', isActive: true, clauses: [] },
+    { versionId: '2', templateId: 't1', versionNo: '2', createdAt: new Date(), createdBy: 'B', isActive: false, clauses: [] }
+  ];
+
+  it('emits events when buttons clicked', () => {
+    const activate = cy.stub().as('activate');
+    const compare = cy.stub().as('compare');
+    const close = cy.stub().as('close');
+    mount(TemplateVersionDrawerComponent, {
+      componentProperties: {
+        versions,
+        open: true,
+        activateVersion: { emit: activate } as any,
+        compareVersion: { emit: compare } as any,
+        close: { emit: close } as any
+      }
+    });
+    cy.get('button.text-blue-600').click();
+    cy.get('@' + 'compare').should('have.been.calledWith', '1');
+    cy.get('button.text-green-600').click();
+    cy.get('@' + 'activate').should('have.been.calledWith', '2');
+    cy.get('div.flex-1').click();
+    cy.get('@' + 'close').should('have.been.called');
+  });
+});

--- a/cypress/support/component/template-wizard.component.cy.ts
+++ b/cypress/support/component/template-wizard.component.cy.ts
@@ -1,0 +1,21 @@
+import { mount } from 'cypress/angular';
+import { TemplateWizardComponent } from '../../../src/app/features/templates/template-wizard.component';
+import { ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs';
+import { MockStandardClauseService } from '../../../src/app/services/mock-standard-clause.service';
+import { TemplatesService } from '../../../src/app/services/templates.service';
+
+describe('TemplateWizardComponent', () => {
+  it('renders first step', () => {
+    const activated = { snapshot: { paramMap: { get: () => null } } };
+    const templatesService = { getOne: () => of({}), create: () => of({}) };
+    mount(TemplateWizardComponent, {
+      providers: [
+        { provide: ActivatedRoute, useValue: activated },
+        { provide: TemplatesService, useValue: templatesService },
+        { provide: MockStandardClauseService, useValue: { getByContractType: () => of([]), create: () => of({}) } }
+      ]
+    });
+    cy.contains('Template Wizard').should('exist');
+  });
+});

--- a/cypress/support/component/templates.component.cy.ts
+++ b/cypress/support/component/templates.component.cy.ts
@@ -1,0 +1,11 @@
+import { mount } from 'cypress/angular';
+import { TemplatesComponent } from '../../../src/app/features/templates/templates.component';
+import { TemplateTableComponent } from '../../../src/app/features/templates/template-table.component';
+
+describe('TemplatesComponent', () => {
+  it('renders template list', () => {
+    mount(TemplatesComponent, { imports: [TemplateTableComponent] });
+    cy.contains('Templates').should('exist');
+    cy.get('table').should('exist');
+  });
+});

--- a/src/app/features/templates/add-standard-clause.component.spec.ts
+++ b/src/app/features/templates/add-standard-clause.component.spec.ts
@@ -1,0 +1,45 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AddStandardClauseComponent } from './add-standard-clause.component';
+
+describe('AddStandardClauseComponent', () => {
+  let fixture: ComponentFixture<AddStandardClauseComponent>;
+  let component: AddStandardClauseComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AddStandardClauseComponent]
+    }).compileComponents();
+    fixture = TestBed.createComponent(AddStandardClauseComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should emit save when form is valid and submitted', () => {
+    const saveSpy = spyOn(component.save, 'emit');
+    component.form.setValue({
+      name: 'Clause',
+      type: 'TYPE',
+      text: 'Body',
+      jurisdiction: 'US',
+      allowedDeviations: 1
+    });
+    component.onSubmit();
+    expect(saveSpy).toHaveBeenCalledWith({
+      name: 'Clause',
+      type: 'TYPE',
+      text: 'Body',
+      jurisdiction: 'US',
+      allowedDeviations: 1
+    });
+  });
+
+  it('should emit cancel on onCancel', () => {
+    const cancelSpy = spyOn(component.cancel, 'emit');
+    component.onCancel();
+    expect(cancelSpy).toHaveBeenCalled();
+  });
+});

--- a/src/app/features/templates/clause-card-editor.component.spec.ts
+++ b/src/app/features/templates/clause-card-editor.component.spec.ts
@@ -1,0 +1,40 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ClauseCardEditorComponent } from './clause-card-editor.component';
+import { VersionedClause } from './template-version.model';
+
+describe('ClauseCardEditorComponent', () => {
+  let fixture: ComponentFixture<ClauseCardEditorComponent>;
+  let component: ClauseCardEditorComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ClauseCardEditorComponent]
+    }).compileComponents();
+    fixture = TestBed.createComponent(ClauseCardEditorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should provide default clause when none is set', () => {
+    expect(component.clauseSafe.clauseId).toBe('');
+  });
+
+  it('should emit save with clause data', () => {
+    const saveSpy = spyOn(component.save, 'emit');
+    const clause: VersionedClause = {
+      clauseId: '1',
+      clauseType: 'type',
+      title: 'Title',
+      body: 'Body',
+      ruleJson: { enforcement: 'MUST_HAVE', severity: 'MEDIUM', allowedDeviation: 0, forbiddenPatterns: [] },
+      orderIdx: 0
+    };
+    component.clause = clause;
+    fixture.nativeElement.querySelector('button:last-child').click();
+    expect(saveSpy).toHaveBeenCalledWith(clause);
+  });
+});

--- a/src/app/features/templates/diff-version-dialog.component.spec.ts
+++ b/src/app/features/templates/diff-version-dialog.component.spec.ts
@@ -1,0 +1,27 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DiffVersionDialogComponent } from './diff-version-dialog.component';
+import { TemplateVersion } from './template-version.model';
+
+describe('DiffVersionDialogComponent', () => {
+  let fixture: ComponentFixture<DiffVersionDialogComponent>;
+  let component: DiffVersionDialogComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DiffVersionDialogComponent]
+    }).compileComponents();
+    fixture = TestBed.createComponent(DiffVersionDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should emit close when close button clicked', () => {
+    const closeSpy = spyOn(component.close, 'emit');
+    fixture.nativeElement.querySelector('button').click();
+    expect(closeSpy).toHaveBeenCalled();
+  });
+});

--- a/src/app/features/templates/rule-dialog.component.spec.ts
+++ b/src/app/features/templates/rule-dialog.component.spec.ts
@@ -1,0 +1,41 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RuleDialogComponent } from './rule-dialog.component';
+import { ClauseRule } from './template-version.model';
+
+const rule: ClauseRule = {
+  enforcement: 'MUST_HAVE',
+  severity: 'LOW',
+  allowedDeviation: 0,
+  forbiddenPatterns: []
+};
+
+describe('RuleDialogComponent', () => {
+  let fixture: ComponentFixture<RuleDialogComponent>;
+  let component: RuleDialogComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RuleDialogComponent]
+    }).compileComponents();
+    fixture = TestBed.createComponent(RuleDialogComponent);
+    component = fixture.componentInstance;
+    component.rule = { ...rule };
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should emit save on form submit', () => {
+    const saveSpy = spyOn(component.save, 'emit');
+    fixture.nativeElement.querySelector('form').dispatchEvent(new Event('submit'));
+    expect(saveSpy).toHaveBeenCalledWith(rule);
+  });
+
+  it('should emit cancel on cancel click', () => {
+    const cancelSpy = spyOn(component.cancel, 'emit');
+    fixture.nativeElement.querySelector('button').click();
+    expect(cancelSpy).toHaveBeenCalled();
+  });
+});

--- a/src/app/features/templates/standard-clause-card.component.spec.ts
+++ b/src/app/features/templates/standard-clause-card.component.spec.ts
@@ -1,0 +1,37 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { StandardClauseCardComponent, StandardClauseCardData } from './standard-clause-card.component';
+
+describe('StandardClauseCardComponent', () => {
+  let fixture: ComponentFixture<StandardClauseCardComponent>;
+  let component: StandardClauseCardComponent;
+
+  const clause: StandardClauseCardData = {
+    id: '1',
+    name: 'Test',
+    type: 'TYPE',
+    text: 'Body',
+    jurisdiction: 'US',
+    allowedDeviations: 0,
+    version: '1.0'
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [StandardClauseCardComponent]
+    }).compileComponents();
+    fixture = TestBed.createComponent(StandardClauseCardComponent);
+    component = fixture.componentInstance;
+    component.clause = clause;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should toggle expand state', () => {
+    expect(component.isExpanded).toBe(false);
+    component.toggleExpand();
+    expect(component.isExpanded).toBe(true);
+  });
+});

--- a/src/app/features/templates/standard-clause-form-dialog.component.spec.ts
+++ b/src/app/features/templates/standard-clause-form-dialog.component.spec.ts
@@ -1,0 +1,43 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { StandardClauseFormDialogComponent } from './standard-clause-form-dialog.component';
+import { CreateStandardClauseDto } from '../standard-clauses/models/standard-clause.model';
+
+const clause: CreateStandardClauseDto = {
+  name: 'Test',
+  type: 'TYPE',
+  text: 'Body',
+  jurisdiction: 'US',
+  allowedDeviations: 0,
+  contractType: 'NDA',
+  version: '1.0'
+};
+
+describe('StandardClauseFormDialogComponent', () => {
+  let fixture: ComponentFixture<StandardClauseFormDialogComponent>;
+  let component: StandardClauseFormDialogComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [StandardClauseFormDialogComponent]
+    }).compileComponents();
+    fixture = TestBed.createComponent(StandardClauseFormDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should emit save on onSave', () => {
+    const saveSpy = spyOn(component.save, 'emit');
+    component.onSave(clause);
+    expect(saveSpy).toHaveBeenCalledWith(clause);
+  });
+
+  it('should emit cancel on onCancel', () => {
+    const cancelSpy = spyOn(component.cancel, 'emit');
+    component.onCancel();
+    expect(cancelSpy).toHaveBeenCalled();
+  });
+});

--- a/src/app/features/templates/standard-clause-form-dialog.component.ts
+++ b/src/app/features/templates/standard-clause-form-dialog.component.ts
@@ -1,7 +1,7 @@
 import { Component, Output, EventEmitter } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { StandardClauseFormComponent } from '../standard-clauses/standard-clause-form/standard-clause-form.component';
-import { CreateStandardClauseDto } from '../../services/standard-clause.service';
+import { CreateStandardClauseDto } from '../standard-clauses/models/standard-clause.model';
 
 @Component({
   selector: 'app-standard-clause-form-dialog',

--- a/src/app/features/templates/standard-clause-selector.component.spec.ts
+++ b/src/app/features/templates/standard-clause-selector.component.spec.ts
@@ -1,0 +1,52 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { StandardClauseSelectorComponent } from './standard-clause-selector.component';
+import { StandardClause, IStandardClauseService } from '../standard-clauses/models/standard-clause.model';
+import { STANDARD_CLAUSE_SERVICE_TOKEN } from '../standard-clauses/standard-clause-service.token';
+
+const clauses: StandardClause[] = [
+  { id: 1, name: 'Clause', type: 'TYPE', text: 'Text', jurisdiction: 'US', allowedDeviations: 0, version: '1.0', contractType: 'NDA', createdAt: new Date(), updatedAt: new Date() }
+];
+
+class MockService implements IStandardClauseService {
+  getAll() { return of(clauses); }
+  getByContractType() { return of(clauses); }
+  create() { return of(); }
+  getOne() { return of(clauses[0]); }
+  getByType() { return of(clauses); }
+  update() { return of(clauses[0]); }
+  delete() { return of(); }
+}
+
+describe('StandardClauseSelectorComponent', () => {
+  let fixture: ComponentFixture<StandardClauseSelectorComponent>;
+  let component: StandardClauseSelectorComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [StandardClauseSelectorComponent],
+      providers: [
+        { provide: STANDARD_CLAUSE_SERVICE_TOKEN, useClass: MockService }
+      ]
+    }).compileComponents();
+    fixture = TestBed.createComponent(StandardClauseSelectorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create and load clauses', () => {
+    expect(component.standardClauses.length).toBe(1);
+  });
+
+  it('should emit select on onSelect', () => {
+    const spy = spyOn(component.select, 'emit');
+    component.onSelect(clauses[0]);
+    expect(spy).toHaveBeenCalledWith(clauses[0]);
+  });
+
+  it('should emit cancel on onCancel', () => {
+    const spy = spyOn(component.cancel, 'emit');
+    component.onCancel();
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/src/app/features/templates/standard-clause-selector.component.ts
+++ b/src/app/features/templates/standard-clause-selector.component.ts
@@ -1,7 +1,7 @@
 import { Component, Output, EventEmitter, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { IStandardClauseService, StandardClause } from '../standard-clauses/models/standard-clause.model';
-import { STANDARD_CLAUSE_SERVICE_TOKEN } from '../standard-clauses/standard-clauses.module';
+import { STANDARD_CLAUSE_SERVICE_TOKEN } from '../standard-clauses/standard-clause-service.token';
 
 @Component({
   selector: 'app-standard-clause-selector',

--- a/src/app/features/templates/template-version-drawer.component.spec.ts
+++ b/src/app/features/templates/template-version-drawer.component.spec.ts
@@ -1,0 +1,46 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TemplateVersionDrawerComponent } from './template-version-drawer.component';
+import { TemplateVersion } from './template-version.model';
+
+const versions: TemplateVersion[] = [
+  { versionId: '1', templateId: 't1', versionNo: '1', createdAt: new Date(), createdBy: 'A', isActive: true, clauses: [] },
+  { versionId: '2', templateId: 't1', versionNo: '2', createdAt: new Date(), createdBy: 'B', isActive: false, clauses: [] }
+];
+
+describe('TemplateVersionDrawerComponent', () => {
+  let fixture: ComponentFixture<TemplateVersionDrawerComponent>;
+  let component: TemplateVersionDrawerComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TemplateVersionDrawerComponent]
+    }).compileComponents();
+    fixture = TestBed.createComponent(TemplateVersionDrawerComponent);
+    component = fixture.componentInstance;
+    component.versions = versions;
+    component.open = true;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should emit activateVersion', () => {
+    const spy = spyOn(component.activateVersion, 'emit');
+    fixture.nativeElement.querySelector('button.text-green-600').click();
+    expect(spy).toHaveBeenCalledWith('2');
+  });
+
+  it('should emit compareVersion', () => {
+    const spy = spyOn(component.compareVersion, 'emit');
+    fixture.nativeElement.querySelector('button.text-blue-600').click();
+    expect(spy).toHaveBeenCalledWith('1');
+  });
+
+  it('should emit close on overlay click', () => {
+    const spy = spyOn(component.close, 'emit');
+    fixture.nativeElement.querySelector('div.flex-1').click();
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/src/app/features/templates/template-wizard.component.spec.ts
+++ b/src/app/features/templates/template-wizard.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { TemplateWizardComponent } from './template-wizard.component';
-import { MockStandardClauseService } from '../../services/mock-standard-clause.service';
+import { MockStandardClauseService } from '../standard-clauses/services/mock-standard-clause.service';
 import { of, throwError } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
 import { TemplatesService } from '../../services/templates.service';


### PR DESCRIPTION
## Summary
- add Karma unit tests for templates feature components
- add Cypress component tests for templates feature
- fix import paths for clause services

## Testing
- `pnpm run test` *(fails: No binary for Chrome browser)*
- `pnpm run e2e` *(fails: Xvfb missing)*