### PR TITLE
Add unit tests for standard-clauses components

### DIFF
--- a/src/app/features/standard-clauses/components/rule-editor/rule-editor.component.spec.ts
+++ b/src/app/features/standard-clauses/components/rule-editor/rule-editor.component.spec.ts
@@ -1,0 +1,33 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RuleEditorComponent } from './rule-editor.component';
+import { Enforcement, Severity } from '../../models/rule.model';
+
+describe('RuleEditorComponent', () => {
+  let fixture: ComponentFixture<RuleEditorComponent>;
+  let component: RuleEditorComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RuleEditorComponent]
+    }).compileComponents();
+    fixture = TestBed.createComponent(RuleEditorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should emit ruleChange when form valid', () => {
+    const spy = spyOn(component.ruleChange, 'emit');
+    component.ruleForm.patchValue({
+      enforcement: Enforcement.MUST_HAVE,
+      severity: Severity.HIGH,
+      similarityThreshold: 90,
+      scoreWeight: 1
+    });
+    fixture.detectChanges();
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/src/app/features/standard-clauses/components/rule-preview/rule-preview.component.spec.ts
+++ b/src/app/features/standard-clauses/components/rule-preview/rule-preview.component.spec.ts
@@ -1,0 +1,34 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RulePreviewComponent } from './rule-preview.component';
+import { ClauseRule, Enforcement, Severity } from '../../models/rule.model';
+
+describe('RulePreviewComponent', () => {
+  let fixture: ComponentFixture<RulePreviewComponent>;
+  let component: RulePreviewComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RulePreviewComponent]
+    }).compileComponents();
+    fixture = TestBed.createComponent(RulePreviewComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should compute severity class', () => {
+    const rule: ClauseRule = {
+      enforcement: Enforcement.MUST_HAVE,
+      severity: Severity.HIGH,
+      similarityThreshold: 100,
+      patterns: []
+    } as ClauseRule;
+    component.rule = rule;
+    component.clauseText = 'text';
+    fixture.detectChanges();
+    expect(component.severityClass()).toBe('severity-high');
+    expect(component.previewMessage()).toContain('severity');
+  });
+});

--- a/src/app/features/standard-clauses/components/template-wizard/template-rules-step.component.spec.ts
+++ b/src/app/features/standard-clauses/components/template-wizard/template-rules-step.component.spec.ts
@@ -1,0 +1,48 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatIconModule } from '@angular/material/icon';
+import { RuleEditorComponent } from '../rule-editor/rule-editor.component';
+import { RulePreviewComponent } from '../rule-preview/rule-preview.component';
+import { TemplateRulesStepComponent } from './template-rules-step.component';
+import { ClauseRule, Enforcement, Severity } from '../../models/rule.model';
+
+describe('TemplateRulesStepComponent', () => {
+  let fixture: ComponentFixture<TemplateRulesStepComponent>;
+  let component: TemplateRulesStepComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        TemplateRulesStepComponent,
+        RuleEditorComponent,
+        RulePreviewComponent,
+        FormsModule,
+        MatDividerModule,
+        MatIconModule
+      ]
+    }).compileComponents();
+    fixture = TestBed.createComponent(TemplateRulesStepComponent);
+    component = fixture.componentInstance;
+    component.clausesData = [
+      { id: '1', title: 'c1', text: 't1' },
+      { id: '2', title: 'c2', text: 't2' }
+    ];
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should load clauses from input', () => {
+    expect(component.clauses().length).toBe(2);
+  });
+
+  it('should emit rulesChange on rule change', () => {
+    const spy = spyOn(component.rulesChange, 'emit');
+    const rule: ClauseRule = { enforcement: Enforcement.MUST_HAVE, severity: Severity.LOW, patterns: [] } as ClauseRule;
+    component.onRuleChange('1', rule);
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/src/app/features/standard-clauses/standard-clause-form/standard-clause-form.component.spec.ts
+++ b/src/app/features/standard-clauses/standard-clause-form/standard-clause-form.component.spec.ts
@@ -1,0 +1,64 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { of } from 'rxjs';
+import { StandardClauseFormComponent } from './standard-clause-form.component';
+import { STANDARD_CLAUSE_SERVICE_TOKEN } from '../standard-clause-service.token';
+import { IStandardClauseService, StandardClause } from '../models/standard-clause.model';
+
+class MockService implements IStandardClauseService {
+  create = jasmine.createSpy().and.returnValue(of({} as StandardClause));
+  update = jasmine.createSpy().and.returnValue(of({} as StandardClause));
+  getAll() { return of([]); }
+  getOne() { return of({} as StandardClause); }
+  getByType() { return of([]); }
+  getByContractType() { return of([]); }
+  delete() { return of(); }
+}
+
+describe('StandardClauseFormComponent', () => {
+  let fixture: ComponentFixture<StandardClauseFormComponent>;
+  let component: StandardClauseFormComponent;
+  let router: jasmine.SpyObj<Router>;
+  let service: MockService;
+
+  beforeEach(async () => {
+    router = jasmine.createSpyObj('Router', ['navigate']);
+    service = new MockService();
+    await TestBed.configureTestingModule({
+      imports: [StandardClauseFormComponent, ReactiveFormsModule],
+      providers: [
+        FormBuilder,
+        { provide: Router, useValue: router },
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: new Map() } } },
+        { provide: STANDARD_CLAUSE_SERVICE_TOKEN, useValue: service }
+      ]
+    }).compileComponents();
+    fixture = TestBed.createComponent(StandardClauseFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    component.clauseForm.setValue({
+      name: 'n',
+      type: 't',
+      text: 'body',
+      jurisdiction: '',
+      version: '',
+      allowedDeviations: '',
+      contractType: ''
+    });
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should call create on submit', () => {
+    component.onSubmit();
+    expect(service.create).toHaveBeenCalled();
+  });
+
+  it('should navigate on cancel', () => {
+    component.onCancel();
+    expect(router.navigate).toHaveBeenCalledWith(['/standard-clauses']);
+  });
+});

--- a/src/app/features/standard-clauses/standard-clause-list/standard-clause-list.component.spec.ts
+++ b/src/app/features/standard-clauses/standard-clause-list/standard-clause-list.component.spec.ts
@@ -1,0 +1,50 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { StandardClauseListComponent } from './standard-clause-list.component';
+import { STANDARD_CLAUSE_SERVICE_TOKEN } from '../standard-clause-service.token';
+import { IStandardClauseService, StandardClause } from '../models/standard-clause.model';
+
+const clauses: StandardClause[] = [
+  { id: 1, name: 'Clause 1', type: 'A', text: 't1', jurisdiction: 'IN', allowedDeviations: 0, contractType: 'NDA', version: '1.0', createdAt: new Date(), updatedAt: new Date() },
+  { id: 2, name: 'Clause 2', type: 'B', text: 't2', jurisdiction: 'US', allowedDeviations: 1, contractType: 'MSA', version: '1.0', createdAt: new Date(), updatedAt: new Date() }
+];
+
+class MockService implements IStandardClauseService {
+  getAll = jasmine.createSpy().and.returnValue(of(clauses));
+  getOne() { return of(clauses[0]); }
+  getByType() { return of(clauses); }
+  getByContractType() { return of(clauses); }
+  create() { return of(clauses[0]); }
+  update() { return of(clauses[0]); }
+  delete = jasmine.createSpy().and.returnValue(of(void 0));
+}
+
+describe('StandardClauseListComponent', () => {
+  let fixture: ComponentFixture<StandardClauseListComponent>;
+  let component: StandardClauseListComponent;
+  let service: MockService;
+
+  beforeEach(async () => {
+    service = new MockService();
+    await TestBed.configureTestingModule({
+      imports: [StandardClauseListComponent],
+      providers: [
+        { provide: STANDARD_CLAUSE_SERVICE_TOKEN, useValue: service }
+      ]
+    }).compileComponents();
+    fixture = TestBed.createComponent(StandardClauseListComponent);
+    component = fixture.componentInstance;
+    spyOn(window, 'confirm').and.returnValue(true);
+    fixture.detectChanges();
+  });
+
+  it('should create and load clauses', () => {
+    expect(component.standardClauses.length).toBe(2);
+    expect(service.getAll).toHaveBeenCalled();
+  });
+
+  it('should call delete on service', () => {
+    component.deleteClause(1);
+    expect(service.delete).toHaveBeenCalledWith(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add Karma specs for standard clause components

## Testing
- `pnpm run test` *(fails: No binary for Chrome browser)*
- `pnpm run e2e` *(fails: missing Xvfb)*