### PR TITLE
Add unit and component tests for contract-review

### DIFF
--- a/cypress/support/component/clause-summary.component.cy.ts
+++ b/cypress/support/component/clause-summary.component.cy.ts
@@ -1,0 +1,9 @@
+import { mount } from 'cypress/angular';
+import { ClauseSummaryComponent } from '../../../src/app/features/contract-review/components/clause-summary/clause-summary.component';
+
+describe('ClauseSummaryComponent', () => {
+  it('renders header', () => {
+    mount(ClauseSummaryComponent);
+    cy.contains('Clause Summary').should('exist');
+  });
+});

--- a/cypress/support/component/contract-analysis.component.cy.ts
+++ b/cypress/support/component/contract-analysis.component.cy.ts
@@ -1,0 +1,22 @@
+import { mount } from 'cypress/angular';
+import { ContractAnalysisComponent } from '../../../src/app/features/contract-review/components/contract-analysis/contract-analysis.component';
+import { ContractAnalysisService } from '../../../src/app/features/contract-review/services/contract-analysis.service';
+import { Router, ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs';
+
+describe('ContractAnalysisComponent', () => {
+  it('renders analysis title', () => {
+    const service = {
+      getCurrentAnalysis: () => of({ analysis: { summary: { title: 'Test' } }, fileName: 'file' }),
+      exportAnalysis: () => of(new Blob())
+    } as Partial<ContractAnalysisService>;
+    mount(ContractAnalysisComponent, {
+      providers: [
+        { provide: ContractAnalysisService, useValue: service },
+        { provide: Router, useValue: {} },
+        { provide: ActivatedRoute, useValue: {} }
+      ]
+    });
+    cy.contains('Contract Analysis').should('exist');
+  });
+});

--- a/cypress/support/component/contract-review.component.cy.ts
+++ b/cypress/support/component/contract-review.component.cy.ts
@@ -1,0 +1,19 @@
+import { mount } from 'cypress/angular';
+import { ContractReviewComponent } from '../../../src/app/features/contract-review/contract-review.component';
+import { StepValidationService } from '../../../src/app/features/contract-review/services/step-validation.service';
+import { Router, ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs';
+
+describe('ContractReviewComponent', () => {
+  it('renders first step', () => {
+    const step = { validateUpload: () => true } as Partial<StepValidationService>;
+    mount(ContractReviewComponent, {
+      providers: [
+        { provide: StepValidationService, useValue: step },
+        { provide: Router, useValue: {} },
+        { provide: ActivatedRoute, useValue: { url: of([]), parent: {} } }
+      ]
+    });
+    cy.contains('Upload Contract').should('exist');
+  });
+});

--- a/cypress/support/component/contract-summary.component.cy.ts
+++ b/cypress/support/component/contract-summary.component.cy.ts
@@ -1,0 +1,22 @@
+import { mount } from 'cypress/angular';
+import { ContractSummaryComponent } from '../../../src/app/features/contract-review/components/contract-summary/contract-summary.component';
+import { ContractAnalysisService } from '../../../src/app/features/contract-review/services/contract-analysis.service';
+import { Router, ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs';
+
+describe('ContractSummaryComponent', () => {
+  it('renders summary title', () => {
+    const service = {
+      getCurrentAnalysis: () => of({ analysis: { summary: { title: 'Test' } }, fileName: 'file' }),
+      exportAnalysis: () => of(new Blob())
+    } as Partial<ContractAnalysisService>;
+    mount(ContractSummaryComponent, {
+      providers: [
+        { provide: ContractAnalysisService, useValue: service },
+        { provide: Router, useValue: {} },
+        { provide: ActivatedRoute, useValue: {} }
+      ]
+    });
+    cy.contains('Contract Summary').should('exist');
+  });
+});

--- a/cypress/support/component/contract-upload.component.cy.ts
+++ b/cypress/support/component/contract-upload.component.cy.ts
@@ -1,0 +1,12 @@
+import { mount } from 'cypress/angular';
+import { ContractUploadComponent } from '../../../src/app/features/contract-review/components/contract-upload/contract-upload.component';
+
+describe('ContractUploadComponent', () => {
+  it('emits data on selection', () => {
+    const emit = cy.stub().as('emit');
+    mount(ContractUploadComponent, { componentProperties: { uploadDataChange: { emit } as any } });
+    cy.get('mat-select[data-cy="contract-type-select"]').click();
+    cy.get('mat-option').contains('Service Agreement').click();
+    cy.get('@emit').should('have.been.called');
+  });
+});

--- a/cypress/support/component/legal-qa.component.cy.ts
+++ b/cypress/support/component/legal-qa.component.cy.ts
@@ -1,0 +1,30 @@
+import { mount } from 'cypress/angular';
+import { LegalQAComponent } from '../../../src/app/features/contract-review/components/legal-qa/legal-qa.component';
+import { ContractAnalysisService } from '../../../src/app/features/contract-review/services/contract-analysis.service';
+import { Router, ActivatedRoute } from '@angular/router';
+import { FocusMonitor, LiveAnnouncer } from '@angular/cdk/a11y';
+import { of } from 'rxjs';
+
+class FocusMonitorStub {
+  monitor() { return of(null); }
+  stopMonitoring() {}
+}
+
+describe('LegalQAComponent', () => {
+  it('asks a question', () => {
+    const service = {
+      getCurrentAnalysis: () => of({}),
+      getAIResponse: () => Promise.resolve('ans')
+    } as Partial<ContractAnalysisService>;
+    mount(LegalQAComponent, {
+      providers: [
+        { provide: ContractAnalysisService, useValue: service },
+        { provide: Router, useValue: {} },
+        { provide: ActivatedRoute, useValue: {} },
+        { provide: FocusMonitor, useClass: FocusMonitorStub },
+        { provide: LiveAnnouncer, useValue: { announce: () => {} } }
+      ]
+    });
+    cy.contains('Legal Q&A').should('exist');
+  });
+});

--- a/cypress/support/component/risk-flags.component.cy.ts
+++ b/cypress/support/component/risk-flags.component.cy.ts
@@ -1,0 +1,26 @@
+import { mount } from 'cypress/angular';
+import { RiskFlagsComponent, RiskFlagNotesDialogComponent } from '../../../src/app/features/contract-review/components/risk-flags/risk-flags.component';
+import { ContractAnalysisService } from '../../../src/app/features/contract-review/services/contract-analysis.service';
+import { MatDialog } from '@angular/material/dialog';
+import { Router, ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs';
+
+describe('RiskFlagsComponent', () => {
+  it('renders risk flags', () => {
+    const analysis = { analysis: { riskFlags: [] } } as any;
+    const service = {
+      getCurrentAnalysis: () => of(analysis),
+      updateRiskFlag: () => {}
+    } as Partial<ContractAnalysisService>;
+    mount(RiskFlagsComponent, {
+      imports: [RiskFlagNotesDialogComponent],
+      providers: [
+        { provide: ContractAnalysisService, useValue: service },
+        { provide: MatDialog, useValue: { open: () => ({ afterClosed: () => of('') }) } },
+        { provide: Router, useValue: {} },
+        { provide: ActivatedRoute, useValue: {} }
+      ]
+    });
+    cy.contains('Risk Flags').should('exist');
+  });
+});

--- a/src/app/features/contract-review/components/clause-summary/clause-summary.component.spec.ts
+++ b/src/app/features/contract-review/components/clause-summary/clause-summary.component.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+import { ClauseSummaryComponent } from './clause-summary.component';
+
+describe('ClauseSummaryComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ClauseSummaryComponent]
+    }).compileComponents();
+  });
+
+  it('should create', () => {
+    const fixture = TestBed.createComponent(ClauseSummaryComponent);
+    const component = fixture.componentInstance;
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/contract-review/components/contract-analysis/contract-analysis.component.spec.ts
+++ b/src/app/features/contract-review/components/contract-analysis/contract-analysis.component.spec.ts
@@ -1,0 +1,36 @@
+import { TestBed } from '@angular/core/testing';
+import { ContractAnalysisComponent } from './contract-analysis.component';
+import { ContractAnalysisService } from '../../services/contract-analysis.service';
+import { of } from 'rxjs';
+import { Router, ActivatedRoute } from '@angular/router';
+
+describe('ContractAnalysisComponent', () => {
+  let serviceSpy: jasmine.SpyObj<ContractAnalysisService>;
+
+  beforeEach(async () => {
+    serviceSpy = jasmine.createSpyObj('ContractAnalysisService', ['getCurrentAnalysis', 'exportAnalysis']);
+    serviceSpy.getCurrentAnalysis.and.returnValue(of(null));
+    await TestBed.configureTestingModule({
+      imports: [ContractAnalysisComponent],
+      providers: [
+        { provide: ContractAnalysisService, useValue: serviceSpy },
+        { provide: Router, useValue: { navigate: () => {} } },
+        { provide: ActivatedRoute, useValue: {} }
+      ]
+    }).compileComponents();
+  });
+
+  it('should create', () => {
+    const fixture = TestBed.createComponent(ContractAnalysisComponent);
+    const component = fixture.componentInstance;
+    expect(component).toBeTruthy();
+  });
+
+  it('should call exportAnalysis', async () => {
+    const fixture = TestBed.createComponent(ContractAnalysisComponent);
+    const component = fixture.componentInstance;
+    serviceSpy.exportAnalysis.and.returnValue(of(new Blob()));
+    await component.exportAnalysis();
+    expect(serviceSpy.exportAnalysis).toHaveBeenCalled();
+  });
+});

--- a/src/app/features/contract-review/components/contract-summary/contract-summary.component.spec.ts
+++ b/src/app/features/contract-review/components/contract-summary/contract-summary.component.spec.ts
@@ -1,0 +1,36 @@
+import { TestBed } from '@angular/core/testing';
+import { ContractSummaryComponent } from './contract-summary.component';
+import { ContractAnalysisService } from '../../services/contract-analysis.service';
+import { of } from 'rxjs';
+import { Router, ActivatedRoute } from '@angular/router';
+
+describe('ContractSummaryComponent', () => {
+  let serviceSpy: jasmine.SpyObj<ContractAnalysisService>;
+
+  beforeEach(async () => {
+    serviceSpy = jasmine.createSpyObj('ContractAnalysisService', ['getCurrentAnalysis', 'exportAnalysis']);
+    serviceSpy.getCurrentAnalysis.and.returnValue(of(null));
+    await TestBed.configureTestingModule({
+      imports: [ContractSummaryComponent],
+      providers: [
+        { provide: ContractAnalysisService, useValue: serviceSpy },
+        { provide: Router, useValue: { navigate: () => {} } },
+        { provide: ActivatedRoute, useValue: {} }
+      ]
+    }).compileComponents();
+  });
+
+  it('should create', () => {
+    const fixture = TestBed.createComponent(ContractSummaryComponent);
+    const component = fixture.componentInstance;
+    expect(component).toBeTruthy();
+  });
+
+  it('should call exportAnalysis', async () => {
+    const fixture = TestBed.createComponent(ContractSummaryComponent);
+    const component = fixture.componentInstance;
+    serviceSpy.exportAnalysis.and.returnValue(of(new Blob()));
+    await component.exportAnalysis();
+    expect(serviceSpy.exportAnalysis).toHaveBeenCalled();
+  });
+});

--- a/src/app/features/contract-review/components/contract-upload/contract-upload.component.spec.ts
+++ b/src/app/features/contract-review/components/contract-upload/contract-upload.component.spec.ts
@@ -1,0 +1,31 @@
+import { TestBed } from '@angular/core/testing';
+import { ContractUploadComponent } from './contract-upload.component';
+
+describe('ContractUploadComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ContractUploadComponent]
+    }).compileComponents();
+  });
+
+  it('should create', () => {
+    const fixture = TestBed.createComponent(ContractUploadComponent);
+    const component = fixture.componentInstance;
+    expect(component).toBeTruthy();
+  });
+
+  it('should emit data on contract type change', () => {
+    const fixture = TestBed.createComponent(ContractUploadComponent);
+    const component = fixture.componentInstance;
+    const spy = spyOn(component.uploadDataChange, 'emit');
+    component.contractType = 'service';
+    component.onContractTypeChange();
+    expect(spy).toHaveBeenCalledWith({ contractType: 'service', selectedFile: null });
+  });
+
+  it('should format file size', () => {
+    const fixture = TestBed.createComponent(ContractUploadComponent);
+    const component = fixture.componentInstance;
+    expect(component.formatFileSize(1024)).toBe('1 KB');
+  });
+});

--- a/src/app/features/contract-review/components/legal-qa/legal-qa.component.spec.ts
+++ b/src/app/features/contract-review/components/legal-qa/legal-qa.component.spec.ts
@@ -1,0 +1,56 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { LegalQAComponent } from './legal-qa.component';
+import { ContractAnalysisService } from '../../services/contract-analysis.service';
+import { of } from 'rxjs';
+import { Router, ActivatedRoute } from '@angular/router';
+import { LiveAnnouncer } from '@angular/cdk/a11y';
+import { FocusMonitor } from '@angular/cdk/a11y';
+
+class FocusMonitorStub {
+  monitor() { return of(null); }
+  stopMonitoring() {}
+}
+
+class AnnouncerStub {
+  announce() {}
+}
+
+describe('LegalQAComponent', () => {
+  let serviceSpy: jasmine.SpyObj<ContractAnalysisService>;
+
+  beforeEach(async () => {
+    serviceSpy = jasmine.createSpyObj('ContractAnalysisService', ['getCurrentAnalysis', 'getAIResponse']);
+    serviceSpy.getCurrentAnalysis.and.returnValue(of({} as any));
+    serviceSpy.getAIResponse.and.resolveTo('answer');
+
+    await TestBed.configureTestingModule({
+      imports: [LegalQAComponent],
+      providers: [
+        { provide: ContractAnalysisService, useValue: serviceSpy },
+        { provide: Router, useValue: { navigate: () => {} } },
+        { provide: ActivatedRoute, useValue: {} },
+        { provide: FocusMonitor, useClass: FocusMonitorStub },
+        { provide: LiveAnnouncer, useClass: AnnouncerStub }
+      ]
+    }).compileComponents();
+  });
+
+  it('should create', () => {
+    const fixture = TestBed.createComponent(LegalQAComponent);
+    const component = fixture.componentInstance;
+    component.questionInput = { nativeElement: { focus() {} } } as any;
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('should send message', fakeAsync(() => {
+    const fixture = TestBed.createComponent(LegalQAComponent);
+    const component = fixture.componentInstance;
+    component.questionInput = { nativeElement: { focus() {} } } as any;
+    component.currentQuestion = 'test';
+    component.sendMessage();
+    tick();
+    expect(serviceSpy.getAIResponse).toHaveBeenCalledWith('test');
+    expect(component.messages.length).toBe(2);
+  }));
+});

--- a/src/app/features/contract-review/components/risk-flags/risk-flags.component.spec.ts
+++ b/src/app/features/contract-review/components/risk-flags/risk-flags.component.spec.ts
@@ -1,0 +1,47 @@
+import { TestBed } from '@angular/core/testing';
+import { RiskFlagsComponent, RiskFlagNotesDialogComponent } from './risk-flags.component';
+import { ContractAnalysisService } from '../../services/contract-analysis.service';
+import { of } from 'rxjs';
+import { MatDialog } from '@angular/material/dialog';
+import { Router, ActivatedRoute } from '@angular/router';
+
+describe('RiskFlagsComponent', () => {
+  let serviceSpy: jasmine.SpyObj<ContractAnalysisService>;
+  let dialogSpy: jasmine.SpyObj<MatDialog>;
+
+  beforeEach(async () => {
+    serviceSpy = jasmine.createSpyObj('ContractAnalysisService', ['getCurrentAnalysis', 'updateRiskFlag']);
+    serviceSpy.getCurrentAnalysis.and.returnValue(of({ analysis: { riskFlags: [] } } as any));
+    dialogSpy = jasmine.createSpyObj('MatDialog', ['open']);
+    dialogSpy.open.and.returnValue({ afterClosed: () => of('note') } as any);
+
+    await TestBed.configureTestingModule({
+      imports: [RiskFlagsComponent, RiskFlagNotesDialogComponent],
+      providers: [
+        { provide: ContractAnalysisService, useValue: serviceSpy },
+        { provide: MatDialog, useValue: dialogSpy },
+        { provide: Router, useValue: { navigate: () => {} } },
+        { provide: ActivatedRoute, useValue: {} }
+      ]
+    }).compileComponents();
+  });
+
+  it('should create', () => {
+    const fixture = TestBed.createComponent(RiskFlagsComponent);
+    const component = fixture.componentInstance;
+    expect(component).toBeTruthy();
+  });
+
+  it('should get risk type class', () => {
+    const fixture = TestBed.createComponent(RiskFlagsComponent);
+    const component = fixture.componentInstance;
+    expect(component.getRiskTypeClass('high')).toBe('risk-high');
+  });
+
+  it('should add notes', async () => {
+    const fixture = TestBed.createComponent(RiskFlagsComponent);
+    const component = fixture.componentInstance;
+    await component.addNotes({ id: '1', type: 'high', category: '', description: '', clause: '', recommendation: '', status: 'open' });
+    expect(dialogSpy.open).toHaveBeenCalled();
+  });
+});

--- a/src/app/features/contract-review/contract-review.component.spec.ts
+++ b/src/app/features/contract-review/contract-review.component.spec.ts
@@ -1,0 +1,36 @@
+import { TestBed } from '@angular/core/testing';
+import { ContractReviewComponent } from './contract-review.component';
+import { StepValidationService } from './services/step-validation.service';
+import { Router, ActivatedRoute } from '@angular/router';
+
+import { of } from "rxjs";
+describe('ContractReviewComponent', () => {
+  let stepSpy: jasmine.SpyObj<StepValidationService>;
+
+  beforeEach(async () => {
+    stepSpy = jasmine.createSpyObj('StepValidationService', ['validateUpload', 'validateAnalysis', 'validateRiskFlags', 'validateSummary', 'validateQA']);
+    stepSpy.validateUpload.and.returnValue(true);
+    await TestBed.configureTestingModule({
+      imports: [ContractReviewComponent],
+      providers: [
+        { provide: StepValidationService, useValue: stepSpy },
+        { provide: Router, useValue: { navigate: () => {} } },
+        { provide: ActivatedRoute, useValue: { url: of([]), parent: {} } }
+      ]
+    }).compileComponents();
+  });
+
+  it('should create', () => {
+    const fixture = TestBed.createComponent(ContractReviewComponent);
+    const component = fixture.componentInstance;
+    expect(component).toBeTruthy();
+  });
+
+  it('should validate current step', () => {
+    const fixture = TestBed.createComponent(ContractReviewComponent);
+    const component = fixture.componentInstance;
+    component.currentStepIndex = 0;
+    expect(component.isCurrentStepValid()).toBe(true);
+    expect(stepSpy.validateUpload).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add Karma unit tests for contract-review components
- add Cypress component tests for each contract-review component

## Testing
- `pnpm run test` *(fails: No binary for Chrome)*
- `pnpm run e2e` *(fails: missing Xvfb)*
