### PR TITLE
Add dashboard component tests

### DIFF
--- a/cypress/support/component/dashboard-autosave-toolbar.component.cy.ts
+++ b/cypress/support/component/dashboard-autosave-toolbar.component.cy.ts
@@ -1,0 +1,12 @@
+import { mount } from 'cypress/angular';
+import { DashboardAutosaveToolbarComponent } from '../../../src/app/features/dashboard/components/dashboard-autosave-toolbar.component';
+import { provideMockStore } from '@ngrx/store/testing';
+import { initialState } from '../../../src/app/features/dashboard/store/dashboard.reducer';
+
+it('DashboardAutosaveToolbarComponent mounts', () => {
+  const state = { dashboard: { ...initialState, unsavedEdits: [{ clauseId: '1', draft: '' }] } };
+  mount(DashboardAutosaveToolbarComponent, {
+    providers: [provideMockStore({ initialState: state })]
+  });
+  cy.contains('unsaved edits').should('exist');
+});

--- a/cypress/support/component/dashboard-bulk-resolve-toolbar.component.cy.ts
+++ b/cypress/support/component/dashboard-bulk-resolve-toolbar.component.cy.ts
@@ -1,0 +1,12 @@
+import { mount } from 'cypress/angular';
+import { DashboardBulkResolveToolbarComponent } from '../../../src/app/features/dashboard/components/dashboard-bulk-resolve-toolbar.component';
+import { provideMockStore } from '@ngrx/store/testing';
+import { initialState } from '../../../src/app/features/dashboard/store/dashboard.reducer';
+
+it('DashboardBulkResolveToolbarComponent mounts', () => {
+  const state = { dashboard: { ...initialState, selectedRiskIds: ['1'] } };
+  mount(DashboardBulkResolveToolbarComponent, {
+    providers: [provideMockStore({ initialState: state })]
+  });
+  cy.contains('selected').should('exist');
+});

--- a/cypress/support/component/dashboard-chat-assistant.component.cy.ts
+++ b/cypress/support/component/dashboard-chat-assistant.component.cy.ts
@@ -1,0 +1,11 @@
+import { mount } from 'cypress/angular';
+import { DashboardChatAssistantComponent } from '../../../src/app/features/dashboard/components/dashboard-chat-assistant.component';
+import { provideMockStore } from '@ngrx/store/testing';
+import { initialState } from '../../../src/app/features/dashboard/store/dashboard.reducer';
+
+it('DashboardChatAssistantComponent mounts', () => {
+  mount(DashboardChatAssistantComponent, {
+    providers: [provideMockStore({ initialState: { dashboard: initialState } })]
+  });
+  cy.get('div').should('exist');
+});

--- a/cypress/support/component/dashboard-clauses-list.component.cy.ts
+++ b/cypress/support/component/dashboard-clauses-list.component.cy.ts
@@ -1,0 +1,11 @@
+import { mount } from 'cypress/angular';
+import { DashboardClausesListComponent } from '../../../src/app/features/dashboard/components/dashboard-clauses-list.component';
+import { provideMockStore } from '@ngrx/store/testing';
+import { initialState } from '../../../src/app/features/dashboard/store/dashboard.reducer';
+
+it('DashboardClausesListComponent mounts', () => {
+  mount(DashboardClausesListComponent, {
+    providers: [provideMockStore({ initialState: { dashboard: initialState } })]
+  });
+  cy.get('cdk-virtual-scroll-viewport').should('exist');
+});

--- a/cypress/support/component/dashboard-comparison-drawer.component.cy.ts
+++ b/cypress/support/component/dashboard-comparison-drawer.component.cy.ts
@@ -1,0 +1,7 @@
+import { mount } from 'cypress/angular';
+import { DashboardComparisonDrawerComponent } from '../../../src/app/features/dashboard/components/dashboard-comparison-drawer.component';
+
+it('DashboardComparisonDrawerComponent mounts', () => {
+  mount(DashboardComparisonDrawerComponent);
+  cy.get('div').should('exist');
+});

--- a/cypress/support/component/dashboard-compliance-heatmap.component.cy.ts
+++ b/cypress/support/component/dashboard-compliance-heatmap.component.cy.ts
@@ -1,0 +1,11 @@
+import { mount } from 'cypress/angular';
+import { DashboardComplianceHeatmapComponent } from '../../../src/app/features/dashboard/components/dashboard-compliance-heatmap.component';
+import { provideMockStore } from '@ngrx/store/testing';
+import { initialState } from '../../../src/app/features/dashboard/store/dashboard.reducer';
+
+it('DashboardComplianceHeatmapComponent mounts', () => {
+  mount(DashboardComplianceHeatmapComponent, {
+    providers: [provideMockStore({ initialState: { dashboard: initialState } })]
+  });
+  cy.get('table').should('exist');
+});

--- a/cypress/support/component/dashboard-event-timeline.component.cy.ts
+++ b/cypress/support/component/dashboard-event-timeline.component.cy.ts
@@ -1,0 +1,11 @@
+import { mount } from 'cypress/angular';
+import { DashboardEventTimelineComponent } from '../../../src/app/features/dashboard/components/dashboard-event-timeline.component';
+import { provideMockStore } from '@ngrx/store/testing';
+import { initialState } from '../../../src/app/features/dashboard/store/dashboard.reducer';
+
+it('DashboardEventTimelineComponent mounts', () => {
+  mount(DashboardEventTimelineComponent, {
+    providers: [provideMockStore({ initialState: { dashboard: initialState } })]
+  });
+  cy.get('div').should('exist');
+});

--- a/cypress/support/component/dashboard-filter-bar.component.cy.ts
+++ b/cypress/support/component/dashboard-filter-bar.component.cy.ts
@@ -1,0 +1,11 @@
+import { mount } from 'cypress/angular';
+import { DashboardFilterBarComponent } from '../../../src/app/features/dashboard/components/dashboard-filter-bar.component';
+import { provideMockStore } from '@ngrx/store/testing';
+import { initialState } from '../../../src/app/features/dashboard/store/dashboard.reducer';
+
+it('DashboardFilterBarComponent mounts', () => {
+  mount(DashboardFilterBarComponent, {
+    providers: [provideMockStore({ initialState: { dashboard: initialState } })]
+  });
+  cy.get('input').should('exist');
+});

--- a/cypress/support/component/dashboard-header.component.cy.ts
+++ b/cypress/support/component/dashboard-header.component.cy.ts
@@ -1,0 +1,7 @@
+import { mount } from 'cypress/angular';
+import { DashboardHeaderComponent } from '../../../src/app/features/dashboard/components/dashboard-header.component';
+
+it('DashboardHeaderComponent mounts', () => {
+  mount(DashboardHeaderComponent);
+  cy.get('div').should('exist');
+});

--- a/cypress/support/component/dashboard-left-rail.component.cy.ts
+++ b/cypress/support/component/dashboard-left-rail.component.cy.ts
@@ -1,0 +1,23 @@
+import { mount } from 'cypress/angular';
+import { DashboardLeftRailComponent } from '../../../src/app/features/dashboard/components/dashboard-left-rail.component';
+import { DashboardRiskCounterComponent } from '../../../src/app/features/dashboard/components/dashboard-risk-counter.component';
+import { DashboardFilterBarComponent } from '../../../src/app/features/dashboard/components/dashboard-filter-bar.component';
+import { DashboardBulkResolveToolbarComponent } from '../../../src/app/features/dashboard/components/dashboard-bulk-resolve-toolbar.component';
+import { DashboardRiskListComponent } from '../../../src/app/features/dashboard/components/dashboard-risk-list.component';
+import { DashboardEventTimelineComponent } from '../../../src/app/features/dashboard/components/dashboard-event-timeline.component';
+import { provideMockStore } from '@ngrx/store/testing';
+import { initialState } from '../../../src/app/features/dashboard/store/dashboard.reducer';
+
+it('DashboardLeftRailComponent mounts', () => {
+  mount(DashboardLeftRailComponent, {
+    imports: [
+      DashboardRiskCounterComponent,
+      DashboardFilterBarComponent,
+      DashboardBulkResolveToolbarComponent,
+      DashboardRiskListComponent,
+      DashboardEventTimelineComponent
+    ],
+    providers: [provideMockStore({ initialState: { dashboard: initialState } })]
+  });
+  cy.get('div').should('exist');
+});

--- a/cypress/support/component/dashboard-main-panel.component.cy.ts
+++ b/cypress/support/component/dashboard-main-panel.component.cy.ts
@@ -1,0 +1,19 @@
+import { mount } from 'cypress/angular';
+import { DashboardMainPanelComponent } from '../../../src/app/features/dashboard/components/dashboard-main-panel.component';
+import { DashboardClausesListComponent } from '../../../src/app/features/dashboard/components/dashboard-clauses-list.component';
+import { DashboardAutosaveToolbarComponent } from '../../../src/app/features/dashboard/components/dashboard-autosave-toolbar.component';
+import { DashboardComplianceHeatmapComponent } from '../../../src/app/features/dashboard/components/dashboard-compliance-heatmap.component';
+import { provideMockStore } from '@ngrx/store/testing';
+import { initialState } from '../../../src/app/features/dashboard/store/dashboard.reducer';
+
+it('DashboardMainPanelComponent mounts', () => {
+  mount(DashboardMainPanelComponent, {
+    imports: [
+      DashboardClausesListComponent,
+      DashboardAutosaveToolbarComponent,
+      DashboardComplianceHeatmapComponent
+    ],
+    providers: [provideMockStore({ initialState: { dashboard: initialState } })]
+  });
+  cy.get('div').should('exist');
+});

--- a/cypress/support/component/dashboard-offline-guard.component.cy.ts
+++ b/cypress/support/component/dashboard-offline-guard.component.cy.ts
@@ -1,0 +1,7 @@
+import { mount } from 'cypress/angular';
+import { DashboardOfflineGuardComponent } from '../../../src/app/features/dashboard/components/dashboard-offline-guard.component';
+
+it('DashboardOfflineGuardComponent mounts', () => {
+  mount(DashboardOfflineGuardComponent);
+  cy.get('div').should('exist');
+});

--- a/cypress/support/component/dashboard-responsive-guard.component.cy.ts
+++ b/cypress/support/component/dashboard-responsive-guard.component.cy.ts
@@ -1,0 +1,7 @@
+import { mount } from 'cypress/angular';
+import { DashboardResponsiveGuardComponent } from '../../../src/app/features/dashboard/components/dashboard-responsive-guard.component';
+
+it('DashboardResponsiveGuardComponent mounts', () => {
+  mount(DashboardResponsiveGuardComponent);
+  cy.get('div').should('exist');
+});

--- a/cypress/support/component/dashboard-risk-counter.component.cy.ts
+++ b/cypress/support/component/dashboard-risk-counter.component.cy.ts
@@ -1,0 +1,11 @@
+import { mount } from 'cypress/angular';
+import { DashboardRiskCounterComponent } from '../../../src/app/features/dashboard/components/dashboard-risk-counter.component';
+import { provideMockStore } from '@ngrx/store/testing';
+import { initialState } from '../../../src/app/features/dashboard/store/dashboard.reducer';
+
+it('DashboardRiskCounterComponent mounts', () => {
+  mount(DashboardRiskCounterComponent, {
+    providers: [provideMockStore({ initialState: { dashboard: initialState } })]
+  });
+  cy.get('div').should('exist');
+});

--- a/cypress/support/component/dashboard-risk-list.component.cy.ts
+++ b/cypress/support/component/dashboard-risk-list.component.cy.ts
@@ -1,0 +1,11 @@
+import { mount } from 'cypress/angular';
+import { DashboardRiskListComponent } from '../../../src/app/features/dashboard/components/dashboard-risk-list.component';
+import { provideMockStore } from '@ngrx/store/testing';
+import { initialState } from '../../../src/app/features/dashboard/store/dashboard.reducer';
+
+it('DashboardRiskListComponent mounts', () => {
+  mount(DashboardRiskListComponent, {
+    providers: [provideMockStore({ initialState: { dashboard: initialState } })]
+  });
+  cy.get('div').should('exist');
+});

--- a/cypress/support/component/dashboard.component.cy.ts
+++ b/cypress/support/component/dashboard.component.cy.ts
@@ -1,0 +1,21 @@
+import { mount } from 'cypress/angular';
+import { DashboardComponent } from '../../../src/app/features/dashboard/dashboard.component';
+import { DashboardHeaderComponent } from '../../../src/app/features/dashboard/components/dashboard-header.component';
+import { DashboardLeftRailComponent } from '../../../src/app/features/dashboard/components/dashboard-left-rail.component';
+import { DashboardMainPanelComponent } from '../../../src/app/features/dashboard/components/dashboard-main-panel.component';
+import { DashboardChatAssistantComponent } from '../../../src/app/features/dashboard/components/dashboard-chat-assistant.component';
+import { provideMockStore } from '@ngrx/store/testing';
+import { initialState } from '../../../src/app/features/dashboard/store/dashboard.reducer';
+
+it('DashboardComponent mounts', () => {
+  mount(DashboardComponent, {
+    imports: [
+      DashboardHeaderComponent,
+      DashboardLeftRailComponent,
+      DashboardMainPanelComponent,
+      DashboardChatAssistantComponent
+    ],
+    providers: [provideMockStore({ initialState: { dashboard: initialState } })]
+  });
+  cy.get('div').should('exist');
+});

--- a/src/app/features/dashboard/components/dashboard-autosave-toolbar.component.spec.ts
+++ b/src/app/features/dashboard/components/dashboard-autosave-toolbar.component.spec.ts
@@ -1,0 +1,36 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideMockStore, MockStore } from '@ngrx/store/testing';
+import { DashboardAutosaveToolbarComponent } from './dashboard-autosave-toolbar.component';
+import { saveAllEdits, discardAllEdits } from '../store/dashboard.actions';
+import { initialState } from '../store/dashboard.reducer';
+
+describe('DashboardAutosaveToolbarComponent', () => {
+  let fixture: ComponentFixture<DashboardAutosaveToolbarComponent>;
+  let component: DashboardAutosaveToolbarComponent;
+  let store: MockStore;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DashboardAutosaveToolbarComponent],
+      providers: [provideMockStore({ initialState: { dashboard: initialState } })]
+    }).compileComponents();
+    fixture = TestBed.createComponent(DashboardAutosaveToolbarComponent);
+    component = fixture.componentInstance;
+    store = TestBed.inject(MockStore);
+    spyOn(store, 'dispatch');
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('saveAll dispatches action', () => {
+    component.saveAll();
+    expect(store.dispatch).toHaveBeenCalledWith(saveAllEdits());
+  });
+
+  it('discardAll dispatches action', () => {
+    component.discardAll();
+    expect(store.dispatch).toHaveBeenCalledWith(discardAllEdits());
+  });
+});

--- a/src/app/features/dashboard/components/dashboard-bulk-resolve-toolbar.component.spec.ts
+++ b/src/app/features/dashboard/components/dashboard-bulk-resolve-toolbar.component.spec.ts
@@ -1,0 +1,46 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideMockStore, MockStore } from '@ngrx/store/testing';
+import { DashboardBulkResolveToolbarComponent } from './dashboard-bulk-resolve-toolbar.component';
+import { bulkResolveRisks, bulkChangeSeverity, bulkDeleteRisks } from '../store/dashboard.actions';
+import { initialState } from '../store/dashboard.reducer';
+import { of } from 'rxjs';
+
+describe('DashboardBulkResolveToolbarComponent', () => {
+  let fixture: ComponentFixture<DashboardBulkResolveToolbarComponent>;
+  let component: DashboardBulkResolveToolbarComponent;
+  let store: MockStore;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DashboardBulkResolveToolbarComponent],
+      providers: [provideMockStore({ initialState: { dashboard: { ...initialState, selectedRiskIds: ['1'] } } })]
+    }).compileComponents();
+    fixture = TestBed.createComponent(DashboardBulkResolveToolbarComponent);
+    component = fixture.componentInstance;
+    store = TestBed.inject(MockStore);
+    spyOn(store, 'dispatch');
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('resolveSelected dispatches bulkResolveRisks', () => {
+    component.selectedRiskIds$ = of(['1']);
+    component.resolveSelected();
+    expect(store.dispatch).toHaveBeenCalledWith(bulkResolveRisks({ riskIds: ['1'] }));
+  });
+
+  it('deleteSelected dispatches bulkDeleteRisks', () => {
+    component.selectedRiskIds$ = of(['1']);
+    component.deleteSelected();
+    expect(store.dispatch).toHaveBeenCalledWith(bulkDeleteRisks({ riskIds: ['1'] }));
+  });
+
+  it('onSeverityChange dispatches bulkChangeSeverity', () => {
+    component.selectedRiskIds$ = of(['1']);
+    const event = { target: { value: 'high' } } as unknown as Event;
+    component.onSeverityChange(event);
+    expect(store.dispatch).toHaveBeenCalledWith(bulkChangeSeverity({ riskIds: ['1'], severity: 'high' }));
+  });
+});

--- a/src/app/features/dashboard/components/dashboard-chat-assistant.component.spec.ts
+++ b/src/app/features/dashboard/components/dashboard-chat-assistant.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideMockStore } from '@ngrx/store/testing';
+import { DashboardChatAssistantComponent } from './dashboard-chat-assistant.component';
+import { initialState } from '../store/dashboard.reducer';
+
+describe('DashboardChatAssistantComponent', () => {
+  let fixture: ComponentFixture<DashboardChatAssistantComponent>;
+  let component: DashboardChatAssistantComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DashboardChatAssistantComponent],
+      providers: [provideMockStore({ initialState: { dashboard: initialState } })]
+    }).compileComponents();
+    fixture = TestBed.createComponent(DashboardChatAssistantComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/dashboard/components/dashboard-clauses-list.component.spec.ts
+++ b/src/app/features/dashboard/components/dashboard-clauses-list.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideMockStore } from '@ngrx/store/testing';
+import { DashboardClausesListComponent } from './dashboard-clauses-list.component';
+import { initialState } from '../store/dashboard.reducer';
+
+describe('DashboardClausesListComponent', () => {
+  let fixture: ComponentFixture<DashboardClausesListComponent>;
+  let component: DashboardClausesListComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DashboardClausesListComponent],
+      providers: [provideMockStore({ initialState: { dashboard: initialState } })]
+    }).compileComponents();
+    fixture = TestBed.createComponent(DashboardClausesListComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/dashboard/components/dashboard-comparison-drawer.component.spec.ts
+++ b/src/app/features/dashboard/components/dashboard-comparison-drawer.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DashboardComparisonDrawerComponent } from './dashboard-comparison-drawer.component';
+
+describe('DashboardComparisonDrawerComponent', () => {
+  let fixture: ComponentFixture<DashboardComparisonDrawerComponent>;
+  let component: DashboardComparisonDrawerComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DashboardComparisonDrawerComponent]
+    }).compileComponents();
+    fixture = TestBed.createComponent(DashboardComparisonDrawerComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should be closed by default', () => {
+    expect(component.isOpen()).toBeFalse();
+  });
+});

--- a/src/app/features/dashboard/components/dashboard-compliance-heatmap.component.spec.ts
+++ b/src/app/features/dashboard/components/dashboard-compliance-heatmap.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideMockStore } from '@ngrx/store/testing';
+import { DashboardComplianceHeatmapComponent } from './dashboard-compliance-heatmap.component';
+import { initialState } from '../store/dashboard.reducer';
+
+describe('DashboardComplianceHeatmapComponent', () => {
+  let fixture: ComponentFixture<DashboardComplianceHeatmapComponent>;
+  let component: DashboardComplianceHeatmapComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DashboardComplianceHeatmapComponent],
+      providers: [provideMockStore({ initialState: { dashboard: initialState } })]
+    }).compileComponents();
+    fixture = TestBed.createComponent(DashboardComplianceHeatmapComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/dashboard/components/dashboard-event-timeline.component.spec.ts
+++ b/src/app/features/dashboard/components/dashboard-event-timeline.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideMockStore } from '@ngrx/store/testing';
+import { DashboardEventTimelineComponent } from './dashboard-event-timeline.component';
+import { initialState } from '../store/dashboard.reducer';
+
+describe('DashboardEventTimelineComponent', () => {
+  let fixture: ComponentFixture<DashboardEventTimelineComponent>;
+  let component: DashboardEventTimelineComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DashboardEventTimelineComponent],
+      providers: [provideMockStore({ initialState: { dashboard: initialState } })]
+    }).compileComponents();
+    fixture = TestBed.createComponent(DashboardEventTimelineComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/dashboard/components/dashboard-filter-bar.component.spec.ts
+++ b/src/app/features/dashboard/components/dashboard-filter-bar.component.spec.ts
@@ -1,0 +1,36 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideMockStore, MockStore } from '@ngrx/store/testing';
+import { DashboardFilterBarComponent } from './dashboard-filter-bar.component';
+import { setFilters } from '../store/dashboard.actions';
+import { initialState } from '../store/dashboard.reducer';
+
+describe('DashboardFilterBarComponent', () => {
+  let fixture: ComponentFixture<DashboardFilterBarComponent>;
+  let component: DashboardFilterBarComponent;
+  let store: MockStore;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DashboardFilterBarComponent],
+      providers: [provideMockStore({ initialState: { dashboard: initialState } })]
+    }).compileComponents();
+    fixture = TestBed.createComponent(DashboardFilterBarComponent);
+    component = fixture.componentInstance;
+    store = TestBed.inject(MockStore);
+    spyOn(store, 'dispatch');
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('toggle adds value when not present', () => {
+    expect(component.toggle(['a'], 'b')).toEqual(['a', 'b']);
+  });
+
+  it('onSearchInput dispatches setFilters', () => {
+    const input = { target: { value: 'test' } } as unknown as Event;
+    component.onSearchInput(input);
+    expect(store.dispatch).toHaveBeenCalledWith(setFilters({ filters: { search: 'test' } }));
+  });
+});

--- a/src/app/features/dashboard/components/dashboard-header.component.spec.ts
+++ b/src/app/features/dashboard/components/dashboard-header.component.spec.ts
@@ -1,0 +1,19 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DashboardHeaderComponent } from './dashboard-header.component';
+
+describe('DashboardHeaderComponent', () => {
+  let fixture: ComponentFixture<DashboardHeaderComponent>;
+  let component: DashboardHeaderComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DashboardHeaderComponent]
+    }).compileComponents();
+    fixture = TestBed.createComponent(DashboardHeaderComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/dashboard/components/dashboard-left-rail.component.spec.ts
+++ b/src/app/features/dashboard/components/dashboard-left-rail.component.spec.ts
@@ -1,0 +1,34 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DashboardLeftRailComponent } from './dashboard-left-rail.component';
+import { DashboardRiskCounterComponent } from './dashboard-risk-counter.component';
+import { DashboardFilterBarComponent } from './dashboard-filter-bar.component';
+import { DashboardBulkResolveToolbarComponent } from './dashboard-bulk-resolve-toolbar.component';
+import { DashboardRiskListComponent } from './dashboard-risk-list.component';
+import { DashboardEventTimelineComponent } from './dashboard-event-timeline.component';
+import { provideMockStore } from '@ngrx/store/testing';
+import { initialState } from '../store/dashboard.reducer';
+
+describe('DashboardLeftRailComponent', () => {
+  let fixture: ComponentFixture<DashboardLeftRailComponent>;
+  let component: DashboardLeftRailComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        DashboardLeftRailComponent,
+        DashboardRiskCounterComponent,
+        DashboardFilterBarComponent,
+        DashboardBulkResolveToolbarComponent,
+        DashboardRiskListComponent,
+        DashboardEventTimelineComponent
+      ],
+      providers: [provideMockStore({ initialState: { dashboard: initialState } })]
+    }).compileComponents();
+    fixture = TestBed.createComponent(DashboardLeftRailComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/dashboard/components/dashboard-main-panel.component.spec.ts
+++ b/src/app/features/dashboard/components/dashboard-main-panel.component.spec.ts
@@ -1,0 +1,40 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideMockStore, MockStore } from '@ngrx/store/testing';
+import { DashboardMainPanelComponent } from './dashboard-main-panel.component';
+import { DashboardClausesListComponent } from './dashboard-clauses-list.component';
+import { DashboardAutosaveToolbarComponent } from './dashboard-autosave-toolbar.component';
+import { DashboardComplianceHeatmapComponent } from './dashboard-compliance-heatmap.component';
+import { setActiveTab } from '../store/dashboard.actions';
+import { initialState } from '../store/dashboard.reducer';
+
+
+describe('DashboardMainPanelComponent', () => {
+  let fixture: ComponentFixture<DashboardMainPanelComponent>;
+  let component: DashboardMainPanelComponent;
+  let store: MockStore;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        DashboardMainPanelComponent,
+        DashboardClausesListComponent,
+        DashboardAutosaveToolbarComponent,
+        DashboardComplianceHeatmapComponent
+      ],
+      providers: [provideMockStore({ initialState: { dashboard: initialState } })]
+    }).compileComponents();
+    fixture = TestBed.createComponent(DashboardMainPanelComponent);
+    component = fixture.componentInstance;
+    store = TestBed.inject(MockStore);
+    spyOn(store, 'dispatch');
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('setTab dispatches setActiveTab', () => {
+    component.setTab('summaries');
+    expect(store.dispatch).toHaveBeenCalledWith(setActiveTab({ tab: 'summaries' } as any));
+  });
+});

--- a/src/app/features/dashboard/components/dashboard-offline-guard.component.spec.ts
+++ b/src/app/features/dashboard/components/dashboard-offline-guard.component.spec.ts
@@ -1,0 +1,19 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DashboardOfflineGuardComponent } from './dashboard-offline-guard.component';
+
+describe('DashboardOfflineGuardComponent', () => {
+  let fixture: ComponentFixture<DashboardOfflineGuardComponent>;
+  let component: DashboardOfflineGuardComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DashboardOfflineGuardComponent]
+    }).compileComponents();
+    fixture = TestBed.createComponent(DashboardOfflineGuardComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/dashboard/components/dashboard-responsive-guard.component.spec.ts
+++ b/src/app/features/dashboard/components/dashboard-responsive-guard.component.spec.ts
@@ -1,0 +1,19 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DashboardResponsiveGuardComponent } from './dashboard-responsive-guard.component';
+
+describe('DashboardResponsiveGuardComponent', () => {
+  let fixture: ComponentFixture<DashboardResponsiveGuardComponent>;
+  let component: DashboardResponsiveGuardComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DashboardResponsiveGuardComponent]
+    }).compileComponents();
+    fixture = TestBed.createComponent(DashboardResponsiveGuardComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/dashboard/components/dashboard-risk-counter.component.spec.ts
+++ b/src/app/features/dashboard/components/dashboard-risk-counter.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideMockStore } from '@ngrx/store/testing';
+import { DashboardRiskCounterComponent } from './dashboard-risk-counter.component';
+import { initialState } from '../store/dashboard.reducer';
+
+describe('DashboardRiskCounterComponent', () => {
+  let fixture: ComponentFixture<DashboardRiskCounterComponent>;
+  let component: DashboardRiskCounterComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DashboardRiskCounterComponent],
+      providers: [provideMockStore({ initialState: { dashboard: initialState } })]
+    }).compileComponents();
+    fixture = TestBed.createComponent(DashboardRiskCounterComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/dashboard/components/dashboard-risk-list.component.spec.ts
+++ b/src/app/features/dashboard/components/dashboard-risk-list.component.spec.ts
@@ -1,0 +1,36 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideMockStore, MockStore } from '@ngrx/store/testing';
+import { DashboardRiskListComponent } from './dashboard-risk-list.component';
+import { selectRisk, deselectRisk } from '../store/dashboard.actions';
+import { initialState } from '../store/dashboard.reducer';
+
+describe('DashboardRiskListComponent', () => {
+  let fixture: ComponentFixture<DashboardRiskListComponent>;
+  let component: DashboardRiskListComponent;
+  let store: MockStore;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DashboardRiskListComponent],
+      providers: [provideMockStore({ initialState: { dashboard: initialState } })]
+    }).compileComponents();
+    fixture = TestBed.createComponent(DashboardRiskListComponent);
+    component = fixture.componentInstance;
+    store = TestBed.inject(MockStore);
+    spyOn(store, 'dispatch');
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('toggleRisk selects risk when not selected', () => {
+    component.toggleRisk('1', []);
+    expect(store.dispatch).toHaveBeenCalledWith(selectRisk({ riskId: '1' }));
+  });
+
+  it('toggleRisk deselects risk when selected', () => {
+    component.toggleRisk('1', ['1']);
+    expect(store.dispatch).toHaveBeenCalledWith(deselectRisk({ riskId: '1' }));
+  });
+});

--- a/src/app/features/dashboard/dashboard.component.spec.ts
+++ b/src/app/features/dashboard/dashboard.component.spec.ts
@@ -1,0 +1,32 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DashboardComponent } from './dashboard.component';
+import { DashboardHeaderComponent } from './components/dashboard-header.component';
+import { DashboardLeftRailComponent } from './components/dashboard-left-rail.component';
+import { DashboardMainPanelComponent } from './components/dashboard-main-panel.component';
+import { DashboardChatAssistantComponent } from './components/dashboard-chat-assistant.component';
+import { provideMockStore } from '@ngrx/store/testing';
+import { initialState } from './store/dashboard.reducer';
+
+describe('DashboardComponent', () => {
+  let fixture: ComponentFixture<DashboardComponent>;
+  let component: DashboardComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        DashboardComponent,
+        DashboardHeaderComponent,
+        DashboardLeftRailComponent,
+        DashboardMainPanelComponent,
+        DashboardChatAssistantComponent
+      ],
+      providers: [provideMockStore({ initialState: { dashboard: initialState } })]
+    }).compileComponents();
+    fixture = TestBed.createComponent(DashboardComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- add Karma unit tests for dashboard components
- add Cypress component tests for dashboard components

## Testing
- `pnpm run test` *(fails: No binary for Chrome)*
- `pnpm run e2e` *(fails: missing Xvfb)*