### PR TITLE
Add basic auth with Google login

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -3,6 +3,9 @@
     <mat-icon>menu</mat-icon>
   </button>
   <span>Contract Review AI</span>
+  <span class="flex-grow"></span>
+  <button *ngIf="isLoggedIn()" mat-button (click)="logout()">Logout</button>
+  <a *ngIf="!isLoggedIn()" mat-button routerLink="/login">Login</a>
 </mat-toolbar>
 
 <mat-sidenav-container>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, signal, inject } from '@angular/core';
 import { Router, RouterOutlet, RouterLink, RouterLinkActive } from '@angular/router';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatSidenavModule } from '@angular/material/sidenav';
@@ -6,6 +6,7 @@ import { MatListModule } from '@angular/material/list';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { CommonModule } from '@angular/common';
+import { AuthService } from './core/auth.service';
 
 @Component({
   selector: 'app-root',
@@ -25,8 +26,15 @@ import { CommonModule } from '@angular/common';
   ]
 })
 export class AppComponent {
-  constructor(private router: Router) {
-    console.log('AppComponent initialized');
+  private auth = inject(AuthService);
+  constructor(private router: Router) {}
+
+  isLoggedIn() {
+    return this.auth.isAuthenticated();
+  }
+
+  logout() {
+    this.auth.logout();
   }
 
   navigate(route: string): void {

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,5 +1,8 @@
 import { Routes } from '@angular/router';
 import { DashboardComponent } from './features/dashboard/dashboard.component';
+import { LoginPageComponent } from './features/auth/login-page.component';
+import { SignupPageComponent } from './features/auth/signup-page.component';
+import { authGuard } from './shared/auth.guard';
 
 export const routes: Routes = [
   {
@@ -8,23 +11,36 @@ export const routes: Routes = [
     pathMatch: 'full'
   },
   {
+    path: 'login',
+    component: LoginPageComponent
+  },
+  {
+    path: 'signup',
+    component: SignupPageComponent
+  },
+  {
     path: 'dashboard',
-    component: DashboardComponent
+    component: DashboardComponent,
+    canActivate: [authGuard]
   },
   {
     path: 'contract-review',
-    loadChildren: () => import('./features/contract-review/contract-review.module').then(m => m.ContractReviewModule)
+    loadChildren: () => import('./features/contract-review/contract-review.module').then(m => m.ContractReviewModule),
+    canActivate: [authGuard]
   },
   {
     path: 'templates',
-    loadChildren: () => import('./features/templates/templates.module').then(m => m.TemplatesModule)
+    loadChildren: () => import('./features/templates/templates.module').then(m => m.TemplatesModule),
+    canActivate: [authGuard]
   },
   {
     path: 'standard-clauses',
-    loadChildren: () => import('./features/standard-clauses/standard-clauses.module').then(m => m.StandardClausesModule)
+    loadChildren: () => import('./features/standard-clauses/standard-clauses.module').then(m => m.StandardClausesModule),
+    canActivate: [authGuard]
   },
   {
     path: 'rules',
-    loadChildren: () => import('./features/rules/rules.module').then(m => m.RulesModule)
+    loadChildren: () => import('./features/rules/rules.module').then(m => m.RulesModule),
+    canActivate: [authGuard]
   }
 ];

--- a/src/app/core/auth.service.ts
+++ b/src/app/core/auth.service.ts
@@ -1,0 +1,50 @@
+import { Injectable, signal } from '@angular/core';
+import { Router } from '@angular/router';
+import { tap } from 'rxjs';
+import { OpenAPI } from '../services/api/core/OpenAPI';
+import { AuthService as ApiAuthService } from '../services/api/services/AuthService';
+import type { AuthEmailLoginDto } from '../services/api/models/AuthEmailLoginDto';
+import type { AuthRegisterLoginDto } from '../services/api/models/AuthRegisterLoginDto';
+import type { AuthGoogleLoginDto } from '../services/api/models/AuthGoogleLoginDto';
+import type { LoginResponseDto } from '../services/api/models/LoginResponseDto';
+import type { User } from '../services/api/models/User';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private token = signal<string | null>(localStorage.getItem('token'));
+  user = signal<User | null>(null);
+
+  constructor(private api: ApiAuthService, private router: Router) {
+    OpenAPI.TOKEN = () => Promise.resolve(this.token() ?? '');
+  }
+
+  isAuthenticated(): boolean {
+    return !!this.token();
+  }
+
+  login(dto: AuthEmailLoginDto) {
+    return this.api.authControllerLoginV1(dto).pipe(tap(res => this.setSession(res)));
+  }
+
+  loginWithGoogle(idToken: string) {
+    const dto: AuthGoogleLoginDto = { idToken };
+    return this.api.authGoogleControllerLoginV1(dto).pipe(tap(res => this.setSession(res)));
+  }
+
+  signUp(dto: AuthRegisterLoginDto) {
+    return this.api.authControllerRegisterV1(dto);
+  }
+
+  logout() {
+    this.token.set(null);
+    this.user.set(null);
+    localStorage.removeItem('token');
+    this.router.navigate(['/login']);
+  }
+
+  private setSession(res: LoginResponseDto) {
+    this.token.set(res.token);
+    this.user.set(res.user);
+    localStorage.setItem('token', res.token);
+  }
+}

--- a/src/app/features/auth/login-page.component.html
+++ b/src/app/features/auth/login-page.component.html
@@ -1,0 +1,14 @@
+<form class="login-form" [formGroup]="form" (ngSubmit)="login()">
+  <mat-form-field appearance="fill">
+    <mat-label>Email</mat-label>
+    <input matInput formControlName="email" type="email" />
+  </mat-form-field>
+  <mat-form-field appearance="fill">
+    <mat-label>Password</mat-label>
+    <input matInput formControlName="password" type="password" />
+  </mat-form-field>
+  <button mat-raised-button color="primary" type="submit">Login</button>
+  <div id="googleBtn" class="mt-4"></div>
+  <p *ngIf="error()" class="error">{{ error() }}</p>
+  <a routerLink="/signup">Create account</a>
+</form>

--- a/src/app/features/auth/login-page.component.scss
+++ b/src/app/features/auth/login-page.component.scss
@@ -1,0 +1,10 @@
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 300px;
+  margin: 2rem auto;
+}
+.error {
+  color: red;
+}

--- a/src/app/features/auth/login-page.component.spec.ts
+++ b/src/app/features/auth/login-page.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideMockStore } from '@ngrx/store/testing';
+import { LoginPageComponent } from './login-page.component';
+
+describe('LoginPageComponent', () => {
+  let fixture: ComponentFixture<LoginPageComponent>;
+  let component: LoginPageComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LoginPageComponent],
+      providers: [provideMockStore({})]
+    }).compileComponents();
+    fixture = TestBed.createComponent(LoginPageComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/auth/login-page.component.ts
+++ b/src/app/features/auth/login-page.component.ts
@@ -1,0 +1,68 @@
+import { Component, OnInit, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Router, RouterLink } from '@angular/router';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { AuthService } from '../../core/auth.service';
+import { environment } from '../../../environments/environment';
+import type { AuthEmailLoginDto } from '../../services/api/models/AuthEmailLoginDto';
+
+declare const google: any;
+
+@Component({
+  selector: 'app-login-page',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    RouterLink,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule
+  ],
+  templateUrl: './login-page.component.html',
+  styleUrls: ['./login-page.component.scss']
+})
+export class LoginPageComponent implements OnInit {
+  private fb = inject(FormBuilder);
+  private auth = inject(AuthService);
+  private router = inject(Router);
+  error = signal<string | null>(null);
+
+  form = this.fb.group({
+    email: ['', [Validators.required, Validators.email]],
+    password: ['', Validators.required]
+  });
+
+  ngOnInit() {
+    if (typeof google !== 'undefined') {
+      google.accounts.id.initialize({
+        client_id: environment.googleClientId,
+        callback: (res: any) => this.handleGoogle(res.credential)
+      });
+      google.accounts.id.renderButton(
+        document.getElementById('googleBtn'),
+        { theme: 'outline', size: 'large' }
+      );
+    }
+  }
+
+  login() {
+    if (this.form.invalid) {
+      return;
+    }
+    this.auth.login(this.form.getRawValue() as unknown as AuthEmailLoginDto).subscribe({
+      next: () => this.router.navigate(['/dashboard']),
+      error: () => this.error.set('Login failed')
+    });
+  }
+
+  private handleGoogle(token: string) {
+    this.auth.loginWithGoogle(token).subscribe({
+      next: () => this.router.navigate(['/dashboard']),
+      error: () => this.error.set('Google login failed')
+    });
+  }
+}

--- a/src/app/features/auth/signup-page.component.html
+++ b/src/app/features/auth/signup-page.component.html
@@ -1,0 +1,22 @@
+<form class="signup-form" [formGroup]="form" (ngSubmit)="signup()">
+  <mat-form-field appearance="fill">
+    <mat-label>First Name</mat-label>
+    <input matInput formControlName="firstName" />
+  </mat-form-field>
+  <mat-form-field appearance="fill">
+    <mat-label>Last Name</mat-label>
+    <input matInput formControlName="lastName" />
+  </mat-form-field>
+  <mat-form-field appearance="fill">
+    <mat-label>Email</mat-label>
+    <input matInput formControlName="email" type="email" />
+  </mat-form-field>
+  <mat-form-field appearance="fill">
+    <mat-label>Password</mat-label>
+    <input matInput formControlName="password" type="password" />
+  </mat-form-field>
+  <button mat-raised-button color="primary" type="submit">Sign Up</button>
+  <div id="googleSignupBtn" class="mt-4"></div>
+  <p *ngIf="error()" class="error">{{ error() }}</p>
+  <a routerLink="/login">Already have an account?</a>
+</form>

--- a/src/app/features/auth/signup-page.component.scss
+++ b/src/app/features/auth/signup-page.component.scss
@@ -1,0 +1,10 @@
+.signup-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 300px;
+  margin: 2rem auto;
+}
+.error {
+  color: red;
+}

--- a/src/app/features/auth/signup-page.component.spec.ts
+++ b/src/app/features/auth/signup-page.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideMockStore } from '@ngrx/store/testing';
+import { SignupPageComponent } from './signup-page.component';
+
+describe('SignupPageComponent', () => {
+  let fixture: ComponentFixture<SignupPageComponent>;
+  let component: SignupPageComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SignupPageComponent],
+      providers: [provideMockStore({})]
+    }).compileComponents();
+    fixture = TestBed.createComponent(SignupPageComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/auth/signup-page.component.ts
+++ b/src/app/features/auth/signup-page.component.ts
@@ -1,0 +1,70 @@
+import { Component, OnInit, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Router, RouterLink } from '@angular/router';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { AuthService } from '../../core/auth.service';
+import { environment } from '../../../environments/environment';
+import type { AuthRegisterLoginDto } from '../../services/api/models/AuthRegisterLoginDto';
+
+declare const google: any;
+
+@Component({
+  selector: 'app-signup-page',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    RouterLink,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule
+  ],
+  templateUrl: './signup-page.component.html',
+  styleUrls: ['./signup-page.component.scss']
+})
+export class SignupPageComponent implements OnInit {
+  private fb = inject(FormBuilder);
+  private auth = inject(AuthService);
+  private router = inject(Router);
+  error = signal<string | null>(null);
+
+  form = this.fb.group({
+    firstName: ['', Validators.required],
+    lastName: ['', Validators.required],
+    email: ['', [Validators.required, Validators.email]],
+    password: ['', Validators.required]
+  });
+
+  ngOnInit() {
+    if (typeof google !== 'undefined') {
+      google.accounts.id.initialize({
+        client_id: environment.googleClientId,
+        callback: (res: any) => this.handleGoogle(res.credential)
+      });
+      google.accounts.id.renderButton(
+        document.getElementById('googleSignupBtn'),
+        { theme: 'outline', size: 'large' }
+      );
+    }
+  }
+
+  signup() {
+    if (this.form.invalid) {
+      return;
+    }
+    this.auth.signUp(this.form.getRawValue() as unknown as AuthRegisterLoginDto).subscribe({
+      next: () => this.router.navigate(['/login']),
+      error: () => this.error.set('Signup failed')
+    });
+  }
+
+  private handleGoogle(token: string) {
+    this.auth.loginWithGoogle(token).subscribe({
+      next: () => this.router.navigate(['/dashboard']),
+      error: () => this.error.set('Google login failed')
+    });
+  }
+}

--- a/src/app/shared/auth.guard.spec.ts
+++ b/src/app/shared/auth.guard.spec.ts
@@ -1,0 +1,30 @@
+import { authGuard } from './auth.guard';
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { AuthService } from '../core/auth.service';
+
+describe('authGuard', () => {
+  it('allows navigation when authenticated', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: Router, useValue: { navigate: jasmine.createSpy('navigate') } },
+        { provide: AuthService, useValue: { isAuthenticated: () => true } }
+      ]
+    });
+    const result = authGuard({} as any, {} as any);
+    expect(result).toBeTrue();
+  });
+
+  it('redirects to login when not authenticated', () => {
+    const navigate = jasmine.createSpy('navigate');
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: Router, useValue: { navigate } },
+        { provide: AuthService, useValue: { isAuthenticated: () => false } }
+      ]
+    });
+    const result = authGuard({} as any, {} as any);
+    expect(result).toBeFalse();
+    expect(navigate).toHaveBeenCalledWith(['/login']);
+  });
+});

--- a/src/app/shared/auth.guard.ts
+++ b/src/app/shared/auth.guard.ts
@@ -1,0 +1,13 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from '../core/auth.service';
+
+export const authGuard: CanActivateFn = () => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
+  if (auth.isAuthenticated()) {
+    return true;
+  }
+  router.navigate(['/login']);
+  return false;
+};

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -1,5 +1,6 @@
 export const environment = {
   production: false,
   apiUrl: 'http://localhost:3000/api',
-  mockData: true // Enable mock data for development
-}; 
+  mockData: true, // Enable mock data for development
+  googleClientId: 'GOOGLE_CLIENT_ID'
+};

--- a/src/environments/environment.e2e.ts
+++ b/src/environments/environment.e2e.ts
@@ -3,5 +3,6 @@ export const environment = {
     apiUrl: 'http://localhost:3000/api',
     mockData: false, // Use real API for E2E
     useMockService: false, // Use real API for E2E
+    googleClientId: 'GOOGLE_CLIENT_ID'
     // ...other env vars
 };

--- a/src/environments/environment.production.ts
+++ b/src/environments/environment.production.ts
@@ -1,5 +1,6 @@
 export const environment = {
   production: true,
   apiUrl: 'http://localhost:3000/api', // TODO: Update with production API URL
-  mockData: false
-}; 
+  mockData: false,
+  googleClientId: 'GOOGLE_CLIENT_ID'
+};

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,5 +1,6 @@
 export const environment = {
   production: false,
   apiUrl: 'http://localhost:3000/api',
-  mockData: true // Enable mock data for development
-}; 
+  mockData: true, // Enable mock data for development
+  googleClientId: 'GOOGLE_CLIENT_ID'
+};


### PR DESCRIPTION
## Summary
- add environment var for Google client
- implement auth service for login, signup and logout
- add login and signup pages with Google login button
- protect routes using auth guard
- show login/logout in toolbar

## Testing
- `pnpm run test` *(fails: No binary for ChromeHeadless)*
- `pnpm run e2e` *(fails: missing Xvfb dependency)*