### PR TITLE
Fix vitest configuration

### DIFF
--- a/src/app/features/contracts/contract-review/services/contract-analysis.service.spec.ts
+++ b/src/app/features/contracts/contract-review/services/contract-analysis.service.spec.ts
@@ -1,8 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { of, firstValueFrom } from 'rxjs';
 import { ContractAnalysisService } from './contract-analysis.service';
-import { ContractsService } from '../../../services/api/services/ContractsService';
-import { HybridReviewService } from '../../../services/api/services/HybridReviewService';
+import { ContractsService, HybridReviewService } from '@api/api';
 
 describe('ContractAnalysisService', () => {
   let service: ContractAnalysisService;

--- a/src/app/features/templates/standard-clause-form-dialog.component.spec.ts
+++ b/src/app/features/templates/standard-clause-form-dialog.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { StandardClauseFormDialogComponent } from './standard-clause-form-dialog.component';
 import { CreateStandardClauseDto } from '../standard-clauses/models/standard-clause.model';
+import { STANDARD_CLAUSE_SERVICE_TOKEN } from '../standard-clauses/standard-clause-service.token';
 
 const clause: CreateStandardClauseDto = {
   name: 'Test',
@@ -19,7 +20,8 @@ describe('StandardClauseFormDialogComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [RouterTestingModule, StandardClauseFormDialogComponent]
+      imports: [RouterTestingModule, StandardClauseFormDialogComponent],
+      providers: [{ provide: STANDARD_CLAUSE_SERVICE_TOKEN, useValue: {} }]
     }).compileComponents();
     fixture = TestBed.createComponent(StandardClauseFormDialogComponent);
     component = fixture.componentInstance;

--- a/src/app/shared/auth.guard.spec.ts
+++ b/src/app/shared/auth.guard.spec.ts
@@ -11,7 +11,7 @@ describe('authGuard', () => {
         { provide: AuthService, useValue: { isAuthenticated: () => true } }
       ]
     });
-    const result = authGuard({} as any, {} as any);
+    const result = TestBed.runInInjectionContext(() => authGuard({} as any, {} as any));
     expect(result).toBeTrue();
   });
 
@@ -23,7 +23,7 @@ describe('authGuard', () => {
         { provide: AuthService, useValue: { isAuthenticated: () => false } }
       ]
     });
-    const result = authGuard({} as any, {} as any);
+    const result = TestBed.runInInjectionContext(() => authGuard({} as any, {} as any));
     expect(result).toBeFalse();
     expect(navigate).toHaveBeenCalledWith(['/login']);
   });

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -12,3 +12,60 @@ getTestBed().initTestEnvironment(
   platformBrowserDynamicTesting()
 );
 
+// Vitest doesn't expose Jasmine globals like `spyOn` by default. Provide minimal
+// shims so existing tests written for Jasmine continue to work.
+import { vi, expect } from 'vitest';
+
+(globalThis as any).spyOn = vi.spyOn;
+(globalThis as any).jasmine = {
+  createSpy: (name?: string) => {
+    const spy = vi.fn();
+    (spy as any).and = {
+      returnValue(value: unknown) {
+        spy.mockReturnValue(value);
+        return spy;
+      },
+      resolveTo(value: unknown) {
+        spy.mockResolvedValue(value);
+        return spy;
+      }
+    };
+    return spy;
+  },
+  createSpyObj: (_name: string, methods: string[]) => {
+    const obj: Record<string, any> = {};
+    for (const m of methods) {
+      const spy = vi.fn();
+      (spy as any).and = {
+        returnValue(value: unknown) {
+          spy.mockReturnValue(value);
+          return spy;
+        },
+        resolveTo(value: unknown) {
+          spy.mockResolvedValue(value);
+          return spy;
+        }
+      };
+      obj[m] = spy;
+    }
+    return obj;
+  }
+};
+
+expect.extend({
+  toBeTrue(received: unknown) {
+    const pass = received === true;
+    return {
+      pass,
+      message: () => `expected ${received} to be true`
+    };
+  },
+  toBeFalse(received: unknown) {
+    const pass = received === false;
+    return {
+      pass,
+      message: () => `expected ${received} to be false`
+    };
+  }
+});
+

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,6 +1,7 @@
 /// <reference types="vitest" />
 
 import angular from '@analogjs/vite-plugin-angular';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 import { defineConfig } from 'vite';
 
@@ -9,7 +10,7 @@ export default defineConfig(({ mode }) => {
   return {
     plugins: [
       angular(),
-      
+      tsconfigPaths(),
     ],
     test: {
       globals: true,


### PR DESCRIPTION
## Summary
- patch vitest setup to mimic jasmine spies and matchers
- enable tsconfig paths in Vite
- adjust imports and test providers
- fix auth guard tests to run within DI context

## Testing
- `pnpm test` *(fails: 26 failed tests)*
- `pnpm run e2e` *(fails to run Cypress: Xvfb missing)*

------
https://chatgpt.com/codex/tasks/task_e_683ee9956898832591c7ee1578114466